### PR TITLE
Temporary fix to wrangler-as-dep compilation issues

### DIFF
--- a/configure_wrangler.sh
+++ b/configure_wrangler.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-pushd deps/wrangler && ./configure && popd
+pushd deps/wrangler && ./configure && make && popd


### PR DESCRIPTION
Added compilation to configure_wrangler script (although this should be done by rebar's compile step).
